### PR TITLE
Fixed a typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Before submitting your contribution, please make sure to take a moment and read through the following guidelines:
 
-- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Development Setup](#development-setup)
 - [Project Structure](#project-structure)
 


### PR DESCRIPTION
This pull request includes a small but important change to the `CONTRIBUTING.md` file. The change corrects the relative path to the `CODE_OF_CONDUCT.md` file.

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L5-R5): Updated the link to the `Code of Conduct` to use the correct relative path.