### PR TITLE
Update website when a new app version is released

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
         branches:
             - main
     repository_dispatch:
-        types: [new_app_version]
+        types: [app_release]
 
 env:
     VITE_BASE: /

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     push:
         branches:
             - main
+    repository_dispatch:
+        types: [new_app_version]
 
 env:
     VITE_BASE: /


### PR DESCRIPTION
This will update the website when a "new_app_version" repo event is received. Example of it being triggered: https://github.com/scb261/website/actions/runs/13632089007

The actual run has failed because I didn't fully configure the deployment on my fork, but you can see that it was successfully triggered by the "new_app_version" event.

The event can be configured to be sent from both the main and the preview repositories.