### PR TITLE
Move 'News' Link from Navbar to Sidebar for Simplified UI

### DIFF
--- a/website/src/.vitepress/config/navigation/navbar.ts
+++ b/website/src/.vitepress/config/navigation/navbar.ts
@@ -20,11 +20,6 @@ const nav: DefaultTheme.NavItem[] = [
     link: '/docs/guides/getting-started',
     activeMatch: '/docs/',
   },
-  {
-    text: 'News',
-    link: '/news/',
-    activeMatch: '/news/',
-  },
 ]
 
 export default nav

--- a/website/src/.vitepress/config/navigation/sidebar.ts
+++ b/website/src/.vitepress/config/navigation/sidebar.ts
@@ -23,6 +23,10 @@ function defaultSidebar(): DefaultTheme.SidebarItem[] {
           link: '/changelogs/',
         },
         {
+          text: 'News',
+          link: '/news',
+        },
+        {
           text: 'Forks',
           link: '/forks/',
         },


### PR DESCRIPTION
This update moves the 'News' link from the top navbar to the sidebar navigation in the docs to declutter the navbar and make it easier for users to find updates while browsing the documentation.